### PR TITLE
feat: 도메인 모델 및 공통 컴포넌트 구성

### DIFF
--- a/src/main/java/com/forex/order/common/ApiResponse.java
+++ b/src/main/java/com/forex/order/common/ApiResponse.java
@@ -1,0 +1,22 @@
+package com.forex.order.common;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+
+    private String code;
+    private String message;
+    private T returnObject;
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>("OK", "SUCCESS", data);
+    }
+
+    public static <T> ApiResponse<T> error(String code, String message) {
+        return new ApiResponse<>(code, message, null);
+    }
+}

--- a/src/main/java/com/forex/order/common/Currency.java
+++ b/src/main/java/com/forex/order/common/Currency.java
@@ -1,0 +1,22 @@
+package com.forex.order.common;
+
+import java.math.BigDecimal;
+
+public enum Currency {
+
+    USD(1),
+    JPY(100),
+    CNY(1),
+    EUR(1),
+    KRW(1);
+
+    private final int unit;
+
+    Currency(int unit) {
+        this.unit = unit;
+    }
+
+    public BigDecimal getUnit() {
+        return BigDecimal.valueOf(unit);
+    }
+}

--- a/src/main/java/com/forex/order/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/forex/order/common/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.forex.order.common;
+
+import com.forex.order.common.exception.InvalidCurrencyException;
+import com.forex.order.common.exception.RateNotAvailableException;
+import com.forex.order.common.exception.RateNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RateNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRateNotFound(RateNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error("NOT_FOUND", e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidCurrencyException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidCurrency(InvalidCurrencyException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("INVALID_CURRENCY", e.getMessage()));
+    }
+
+    @ExceptionHandler(RateNotAvailableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRateNotAvailable(RateNotAvailableException e) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(ApiResponse.error("RATE_NOT_AVAILABLE", e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .findFirst()
+                .orElse("잘못된 요청입니다");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("BAD_REQUEST", message));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("INVALID_CURRENCY", "지원하지 않는 통화입니다"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("INTERNAL_ERROR", "서버 오류가 발생했습니다"));
+    }
+}

--- a/src/main/java/com/forex/order/common/OrderType.java
+++ b/src/main/java/com/forex/order/common/OrderType.java
@@ -1,0 +1,7 @@
+package com.forex.order.common;
+
+public enum OrderType {
+
+    BUY,
+    SELL
+}

--- a/src/main/java/com/forex/order/common/exception/InvalidCurrencyException.java
+++ b/src/main/java/com/forex/order/common/exception/InvalidCurrencyException.java
@@ -1,0 +1,8 @@
+package com.forex.order.common.exception;
+
+public class InvalidCurrencyException extends RuntimeException {
+
+    public InvalidCurrencyException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/forex/order/common/exception/RateNotAvailableException.java
+++ b/src/main/java/com/forex/order/common/exception/RateNotAvailableException.java
@@ -1,0 +1,8 @@
+package com.forex.order.common.exception;
+
+public class RateNotAvailableException extends RuntimeException {
+
+    public RateNotAvailableException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/forex/order/common/exception/RateNotFoundException.java
+++ b/src/main/java/com/forex/order/common/exception/RateNotFoundException.java
@@ -1,0 +1,8 @@
+package com.forex.order.common.exception;
+
+public class RateNotFoundException extends RuntimeException {
+
+    public RateNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/forex/order/exchangerate/ExchangeRateHistory.java
+++ b/src/main/java/com/forex/order/exchangerate/ExchangeRateHistory.java
@@ -1,0 +1,48 @@
+package com.forex.order.exchangerate.entity;
+
+import com.forex.order.common.Currency;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "exchange_rate_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ExchangeRateHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 3)
+    private Currency currency;
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    private BigDecimal tradeStanRate;
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    private BigDecimal buyRate;
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    private BigDecimal sellRate;
+
+    @Column(nullable = false)
+    private LocalDateTime dateTime;
+}

--- a/src/main/java/com/forex/order/exchangerate/repository/ExchangeRateHistoryRepository.java
+++ b/src/main/java/com/forex/order/exchangerate/repository/ExchangeRateHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.forex.order.exchangerate.repository;
+
+import com.forex.order.common.Currency;
+import com.forex.order.exchangerate.entity.ExchangeRateHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ExchangeRateHistoryRepository extends JpaRepository<ExchangeRateHistory, Long> {
+
+    Optional<ExchangeRateHistory> findTopByCurrencyOrderByDateTimeDesc(Currency currency);
+}

--- a/src/main/java/com/forex/order/order/ForexOrder.java
+++ b/src/main/java/com/forex/order/order/ForexOrder.java
@@ -1,0 +1,52 @@
+package com.forex.order.order.entity;
+
+import com.forex.order.common.Currency;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "forex_order")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ForexOrder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    private BigDecimal fromAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 3)
+    private Currency fromCurrency;
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    private BigDecimal toAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 3)
+    private Currency toCurrency;
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    private BigDecimal tradeRate;
+
+    @Column(nullable = false)
+    private LocalDateTime dateTime;
+}

--- a/src/main/java/com/forex/order/order/repository/ForexOrderRepository.java
+++ b/src/main/java/com/forex/order/order/repository/ForexOrderRepository.java
@@ -1,0 +1,11 @@
+package com.forex.order.order.repository;
+
+import com.forex.order.order.entity.ForexOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ForexOrderRepository extends JpaRepository<ForexOrder, Long> {
+
+    List<ForexOrder> findAllByOrderByDateTimeDesc();
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,29 @@
 spring:
   application:
     name: forex-order-system
+  datasource:
+    url: jdbc:h2:mem:forexdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+koreaexim:
+  auth-key: ${KOREAEXIM_AUTH_KEY:}
+
+scheduler:
+  enabled: true
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,9 @@
+spring:
+  jpa:
+    show-sql: false
+
+koreaexim:
+  auth-key: test-key
+
+scheduler:
+  enabled: false


### PR DESCRIPTION
## Summary
- Currency, OrderType Enum 정의
- ExchangeRateHistory, ForexOrder JPA Entity 구성
- 공통 응답 래퍼(ApiResponse), 예외 클래스, GlobalExceptionHandler
- application.yml (H2/JPA/Swagger/스케줄러 설정)

## 설계 결정

### BigDecimal 선택 (Long, double 대비)
금융 데이터의 소수점 정밀도를 `setScale(2, HALF_UP)` 등으로 명시적으로 제어하기 위해 BigDecimal을 채택했습니다. Long은 모든 입출력에 x100 변환이 필요하고, JPY의 100엔 단위와 겹쳐 혼란을 유발합니다. double/float는 부동소수점 오차로 금융 도메인에 부적합합니다.

### Currency Enum에 unit 필드 추가
JPY(100엔 단위)를 if문으로 분기하는 대신, Enum에 `unit` 필드를 두어 계산식을 `forexAmount * rate / currency.getUnit()`으로 통일했습니다. 새로운 100단위 통화가 추가되어도 Enum에 값만 추가하면 됩니다.

### 비즈니스 예외 계층 설계
Service에서 `throw new RateNotFoundException()`만 하면 GlobalExceptionHandler가 자동으로 404 응답을 생성합니다. 예외 타입 → HTTP 상태코드 매핑을 한 곳에서 관리하여 Controller와 Service의 관심사를 분리했습니다.

### Lombok 전략: @Getter + @Builder (setter 미노출)
JPA 엔티티에 @Data를 사용하면 setter 노출, equals/hashCode 프록시 충돌 등의 문제가 있어 @Getter + @NoArgsConstructor(PROTECTED) + @Builder 조합을 선택했습니다.

## Test Plan
- [x] Entity 빌드 및 JPA 매핑 확인 (H2 테이블 생성)
- [x] Repository 메서드 쿼리 동작 검증
- [x] GlobalExceptionHandler 응답 포맷 확인

closes #1