### PR TITLE
feat: 환율 수집 및 조회 기능 구현

### DIFF
--- a/src/main/java/com/forex/order/config/AppConfig.java
+++ b/src/main/java/com/forex/order/config/AppConfig.java
@@ -1,0 +1,28 @@
+package com.forex.order.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+@Configuration
+@EnableScheduling
+public class AppConfig {
+
+    private static final int CONNECT_TIMEOUT_MS = 5000;
+    private static final int READ_TIMEOUT_MS = 5000;
+
+    @Bean
+    public RestClient restClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofMillis(CONNECT_TIMEOUT_MS));
+        factory.setReadTimeout(Duration.ofMillis(READ_TIMEOUT_MS));
+
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+}

--- a/src/main/java/com/forex/order/exchangerate/client/KoreaEximClient.java
+++ b/src/main/java/com/forex/order/exchangerate/client/KoreaEximClient.java
@@ -1,0 +1,11 @@
+package com.forex.order.exchangerate.client;
+
+import com.forex.order.exchangerate.dto.KoreaEximApiResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface KoreaEximClient {
+
+    List<KoreaEximApiResponse> fetchRates(LocalDate date);
+}

--- a/src/main/java/com/forex/order/exchangerate/client/KoreaEximClientImpl.java
+++ b/src/main/java/com/forex/order/exchangerate/client/KoreaEximClientImpl.java
@@ -1,0 +1,43 @@
+package com.forex.order.exchangerate.client;
+
+import com.forex.order.exchangerate.dto.KoreaEximApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KoreaEximClientImpl implements KoreaEximClient {
+
+    private static final String BASE_URL = "https://oapi.koreaexim.go.kr/site/program/financial/exchangeJSON";
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final RestClient restClient;
+
+    @Value("${koreaexim.auth-key}")
+    private String authKey;
+
+    @Override
+    public List<KoreaEximApiResponse> fetchRates(LocalDate date) {
+        String searchDate = date.format(DATE_FORMAT);
+
+        KoreaEximApiResponse[] responses = restClient.get()
+                .uri(BASE_URL + "?authkey={key}&searchdate={date}&data=AP01",
+                        authKey, searchDate)
+                .retrieve()
+                .body(KoreaEximApiResponse[].class);
+
+        if (responses == null) {
+            return List.of();
+        }
+
+        return List.of(responses);
+    }
+}

--- a/src/main/java/com/forex/order/exchangerate/controller/ExchangeRateController.java
+++ b/src/main/java/com/forex/order/exchangerate/controller/ExchangeRateController.java
@@ -1,0 +1,35 @@
+package com.forex.order.exchangerate.controller;
+
+import com.forex.order.common.ApiResponse;
+import com.forex.order.common.Currency;
+import com.forex.order.exchangerate.dto.ExchangeRateResponse;
+import com.forex.order.exchangerate.service.ExchangeRateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/exchange-rate")
+@RequiredArgsConstructor
+public class ExchangeRateController {
+
+    private final ExchangeRateService exchangeRateService;
+
+    @GetMapping("/latest")
+    public ResponseEntity<ApiResponse<List<ExchangeRateResponse>>> getLatestAll() {
+        List<ExchangeRateResponse> rates = exchangeRateService.getLatestAll();
+        return ResponseEntity.ok(ApiResponse.ok(rates));
+    }
+
+    @GetMapping("/latest/{currency}")
+    public ResponseEntity<ApiResponse<ExchangeRateResponse>> getLatest(
+            @PathVariable Currency currency) {
+        ExchangeRateResponse rate = exchangeRateService.getLatest(currency);
+        return ResponseEntity.ok(ApiResponse.ok(rate));
+    }
+}

--- a/src/main/java/com/forex/order/exchangerate/dto/ExchangeRateResponse.java
+++ b/src/main/java/com/forex/order/exchangerate/dto/ExchangeRateResponse.java
@@ -1,0 +1,20 @@
+package com.forex.order.exchangerate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ExchangeRateResponse {
+
+    private String currency;
+    private BigDecimal tradeStanRate;
+    private BigDecimal buyRate;
+    private BigDecimal sellRate;
+    private LocalDateTime dateTime;
+}

--- a/src/main/java/com/forex/order/exchangerate/dto/KoreaEximApiResponse.java
+++ b/src/main/java/com/forex/order/exchangerate/dto/KoreaEximApiResponse.java
@@ -1,0 +1,22 @@
+package com.forex.order.exchangerate.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KoreaEximApiResponse {
+
+    @JsonProperty("cur_unit")
+    private String curUnit;
+
+    @JsonProperty("cur_nm")
+    private String curNm;
+
+    @JsonProperty("deal_bas_r")
+    private String dealBasR;
+
+    @JsonProperty("result")
+    private Integer result;
+}

--- a/src/main/java/com/forex/order/exchangerate/scheduler/ExchangeRateScheduler.java
+++ b/src/main/java/com/forex/order/exchangerate/scheduler/ExchangeRateScheduler.java
@@ -1,0 +1,26 @@
+package com.forex.order.exchangerate.scheduler;
+
+import com.forex.order.exchangerate.service.ExchangeRateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "scheduler.enabled", havingValue = "true", matchIfMissing = true)
+@RequiredArgsConstructor
+@Slf4j
+public class ExchangeRateScheduler {
+
+    private final ExchangeRateService exchangeRateService;
+
+    @Scheduled(fixedDelay = 60000)
+    public void fetchExchangeRates() {
+        try {
+            exchangeRateService.fetchAndSaveRates();
+        } catch (Exception e) {
+            log.warn("환율 수집 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/forex/order/exchangerate/service/ExchangeRateService.java
+++ b/src/main/java/com/forex/order/exchangerate/service/ExchangeRateService.java
@@ -1,44 +1,158 @@
 package com.forex.order.exchangerate.service;
 
 import com.forex.order.common.Currency;
+import com.forex.order.common.exception.RateNotFoundException;
 import com.forex.order.exchangerate.client.KoreaEximClient;
 import com.forex.order.exchangerate.dto.ExchangeRateResponse;
+import com.forex.order.exchangerate.dto.KoreaEximApiResponse;
 import com.forex.order.exchangerate.entity.ExchangeRateHistory;
 import com.forex.order.exchangerate.repository.ExchangeRateHistoryRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ExchangeRateService {
 
+    private static final BigDecimal BUY_SPREAD_RATE = new BigDecimal("1.05");
+    private static final BigDecimal SELL_SPREAD_RATE = new BigDecimal("0.95");
+    private static final int MAX_RETRY_DAYS = 7;
+    private static final Set<Currency> TARGET_CURRENCIES = Set.of(
+            Currency.USD, Currency.JPY, Currency.CNY, Currency.EUR
+    );
+
     private final ExchangeRateHistoryRepository repository;
     private final KoreaEximClient koreaEximClient;
+    private final ConcurrentHashMap<Currency, ExchangeRateHistory> latestRates = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    public void warmUpCache() {
+        for (Currency currency : TARGET_CURRENCIES) {
+            repository.findTopByCurrencyOrderByDateTimeDesc(currency)
+                    .ifPresent(rate -> latestRates.put(currency, rate));
+        }
+        log.info("캐시 워밍 완료: {}개 통화 로드", latestRates.size());
+    }
 
     public void fetchAndSaveRates() {
-        // TODO: 구현 예정
+        LocalDate date = adjustToBusinessDay(LocalDate.now());
+
+        for (int retry = 0; retry < MAX_RETRY_DAYS; retry++) {
+            List<KoreaEximApiResponse> responses = koreaEximClient.fetchRates(date);
+
+            if (!responses.isEmpty()) {
+                processAndSave(responses);
+                return;
+            }
+
+            date = adjustToBusinessDay(date.minusDays(1));
+        }
+
+        log.warn("{}일 이내 유효한 환율 데이터를 찾지 못했습니다", MAX_RETRY_DAYS);
     }
 
     public List<ExchangeRateResponse> getLatestAll() {
-        // TODO: 구현 예정
-        return List.of();
+        if (latestRates.isEmpty()) {
+            throw new RateNotFoundException("수집된 환율 데이터가 없습니다");
+        }
+
+        return latestRates.values().stream()
+                .map(this::toResponse)
+                .toList();
     }
 
     public ExchangeRateResponse getLatest(Currency currency) {
-        // TODO: 구현 예정
-        return null;
+        ExchangeRateHistory rate = latestRates.get(currency);
+        if (rate == null) {
+            throw new RateNotFoundException(currency + " 환율 정보를 찾을 수 없습니다");
+        }
+        return toResponse(rate);
     }
 
     public ExchangeRateHistory getLatestRate(Currency currency) {
-        // TODO: 구현 예정
-        return null;
+        ExchangeRateHistory rate = latestRates.get(currency);
+        if (rate == null) {
+            throw new RateNotFoundException(currency + " 환율 정보를 찾을 수 없습니다");
+        }
+        return rate;
     }
 
-    public void warmUpCache() {
-        // TODO: 구현 예정
+    @Transactional
+    protected void processAndSave(List<KoreaEximApiResponse> responses) {
+        for (KoreaEximApiResponse response : responses) {
+            Currency currency = parseCurrency(response.getCurUnit());
+            if (currency == null || !TARGET_CURRENCIES.contains(currency)) {
+                continue;
+            }
+
+            BigDecimal tradeStanRate = parseRate(response.getDealBasR());
+            BigDecimal buyRate = tradeStanRate.multiply(BUY_SPREAD_RATE)
+                    .setScale(2, RoundingMode.HALF_UP);
+            BigDecimal sellRate = tradeStanRate.multiply(SELL_SPREAD_RATE)
+                    .setScale(2, RoundingMode.HALF_UP);
+
+            ExchangeRateHistory entity = ExchangeRateHistory.builder()
+                    .currency(currency)
+                    .tradeStanRate(tradeStanRate)
+                    .buyRate(buyRate)
+                    .sellRate(sellRate)
+                    .dateTime(LocalDateTime.now())
+                    .build();
+
+            repository.save(entity);
+            latestRates.put(currency, entity);
+        }
+
+        log.info("환율 수집 완료: {}개 통화 갱신", latestRates.size());
+    }
+
+    private Currency parseCurrency(String curUnit) {
+        if (curUnit == null) {
+            return null;
+        }
+
+        String code = curUnit.replaceAll("\\(.*\\)", "").trim();
+
+        try {
+            return Currency.valueOf(code);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private BigDecimal parseRate(String rateString) {
+        String cleaned = rateString.replace(",", "");
+        return new BigDecimal(cleaned);
+    }
+
+    private LocalDate adjustToBusinessDay(LocalDate date) {
+        return switch (date.getDayOfWeek()) {
+            case SATURDAY -> date.minusDays(1);
+            case SUNDAY -> date.minusDays(2);
+            default -> date;
+        };
+    }
+
+    private ExchangeRateResponse toResponse(ExchangeRateHistory entity) {
+        return ExchangeRateResponse.builder()
+                .currency(entity.getCurrency().name())
+                .tradeStanRate(entity.getTradeStanRate())
+                .buyRate(entity.getBuyRate())
+                .sellRate(entity.getSellRate())
+                .dateTime(entity.getDateTime())
+                .build();
     }
 }

--- a/src/main/java/com/forex/order/exchangerate/service/ExchangeRateService.java
+++ b/src/main/java/com/forex/order/exchangerate/service/ExchangeRateService.java
@@ -1,0 +1,44 @@
+package com.forex.order.exchangerate.service;
+
+import com.forex.order.common.Currency;
+import com.forex.order.exchangerate.client.KoreaEximClient;
+import com.forex.order.exchangerate.dto.ExchangeRateResponse;
+import com.forex.order.exchangerate.entity.ExchangeRateHistory;
+import com.forex.order.exchangerate.repository.ExchangeRateHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExchangeRateService {
+
+    private final ExchangeRateHistoryRepository repository;
+    private final KoreaEximClient koreaEximClient;
+
+    public void fetchAndSaveRates() {
+        // TODO: 구현 예정
+    }
+
+    public List<ExchangeRateResponse> getLatestAll() {
+        // TODO: 구현 예정
+        return List.of();
+    }
+
+    public ExchangeRateResponse getLatest(Currency currency) {
+        // TODO: 구현 예정
+        return null;
+    }
+
+    public ExchangeRateHistory getLatestRate(Currency currency) {
+        // TODO: 구현 예정
+        return null;
+    }
+
+    public void warmUpCache() {
+        // TODO: 구현 예정
+    }
+}

--- a/src/test/java/com/forex/order/exchangerate/repository/ExchangeRateHistoryRepositoryTest.java
+++ b/src/test/java/com/forex/order/exchangerate/repository/ExchangeRateHistoryRepositoryTest.java
@@ -1,0 +1,98 @@
+package com.forex.order.exchangerate.repository;
+
+import com.forex.order.common.Currency;
+import com.forex.order.exchangerate.entity.ExchangeRateHistory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ExchangeRateHistoryRepositoryTest {
+
+    @Autowired
+    private ExchangeRateHistoryRepository repository;
+
+    @Test
+    @DisplayName("같은 통화의 여러 환율 중 가장 최신 1건만 반환한다")
+    void findsLatestByCurrency() {
+        // Arrange
+        ExchangeRateHistory older = ExchangeRateHistory.builder()
+                .currency(Currency.USD)
+                .tradeStanRate(new BigDecimal("1340.00"))
+                .buyRate(new BigDecimal("1407.00"))
+                .sellRate(new BigDecimal("1273.00"))
+                .dateTime(LocalDateTime.of(2026, 4, 24, 10, 0))
+                .build();
+
+        ExchangeRateHistory newer = ExchangeRateHistory.builder()
+                .currency(Currency.USD)
+                .tradeStanRate(new BigDecimal("1345.50"))
+                .buyRate(new BigDecimal("1412.78"))
+                .sellRate(new BigDecimal("1278.23"))
+                .dateTime(LocalDateTime.of(2026, 4, 24, 11, 0))
+                .build();
+
+        repository.save(older);
+        repository.save(newer);
+
+        // Act
+        Optional<ExchangeRateHistory> result =
+                repository.findTopByCurrencyOrderByDateTimeDesc(Currency.USD);
+
+        // Assert
+        assertThat(result).isPresent();
+        assertThat(result.get().getTradeStanRate()).isEqualByComparingTo("1345.50");
+    }
+
+    @Test
+    @DisplayName("통화별로 독립적으로 최신 환율을 조회한다")
+    void findsByCurrencyIndependently() {
+        // Arrange
+        ExchangeRateHistory usd = ExchangeRateHistory.builder()
+                .currency(Currency.USD)
+                .tradeStanRate(new BigDecimal("1345.50"))
+                .buyRate(new BigDecimal("1412.78"))
+                .sellRate(new BigDecimal("1278.23"))
+                .dateTime(LocalDateTime.now())
+                .build();
+
+        ExchangeRateHistory jpy = ExchangeRateHistory.builder()
+                .currency(Currency.JPY)
+                .tradeStanRate(new BigDecimal("917.44"))
+                .buyRate(new BigDecimal("963.31"))
+                .sellRate(new BigDecimal("871.57"))
+                .dateTime(LocalDateTime.now())
+                .build();
+
+        repository.save(usd);
+        repository.save(jpy);
+
+        // Act
+        Optional<ExchangeRateHistory> usdResult =
+                repository.findTopByCurrencyOrderByDateTimeDesc(Currency.USD);
+        Optional<ExchangeRateHistory> jpyResult =
+                repository.findTopByCurrencyOrderByDateTimeDesc(Currency.JPY);
+
+        // Assert
+        assertThat(usdResult.get().getCurrency()).isEqualTo(Currency.USD);
+        assertThat(jpyResult.get().getCurrency()).isEqualTo(Currency.JPY);
+    }
+
+    @Test
+    @DisplayName("데이터가 없으면 빈 Optional을 반환한다")
+    void returnsEmptyWhenNone() {
+        // Act
+        Optional<ExchangeRateHistory> result =
+                repository.findTopByCurrencyOrderByDateTimeDesc(Currency.EUR);
+
+        // Assert
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/forex/order/exchangerate/service/ExchangeRateServiceTest.java
+++ b/src/test/java/com/forex/order/exchangerate/service/ExchangeRateServiceTest.java
@@ -1,0 +1,287 @@
+package com.forex.order.exchangerate.service;
+
+import com.forex.order.common.Currency;
+import com.forex.order.common.exception.RateNotFoundException;
+import com.forex.order.exchangerate.client.KoreaEximClient;
+import com.forex.order.exchangerate.dto.ExchangeRateResponse;
+import com.forex.order.exchangerate.dto.KoreaEximApiResponse;
+import com.forex.order.exchangerate.entity.ExchangeRateHistory;
+import com.forex.order.exchangerate.repository.ExchangeRateHistoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ExchangeRateServiceTest {
+
+    @Mock
+    private ExchangeRateHistoryRepository repository;
+
+    @Mock
+    private KoreaEximClient koreaEximClient;
+
+    @InjectMocks
+    private ExchangeRateService exchangeRateService;
+
+    @Nested
+    @DisplayName("환율 수집 및 저장")
+    class FetchAndSaveRates {
+
+        @Test
+        @DisplayName("매매기준율로 buyRate(x1.05)와 sellRate(x0.95)를 계산한다")
+        void calculatesBuyAndSellRate() {
+            // Arrange
+            KoreaEximApiResponse response = createApiResponse("USD", "1,345.50");
+            given(koreaEximClient.fetchRates(any())).willReturn(List.of(response));
+            given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // Act
+            exchangeRateService.fetchAndSaveRates();
+
+            // Assert
+            verify(repository).save(any(ExchangeRateHistory.class));
+        }
+
+        @Test
+        @DisplayName("buyRate는 HALF_UP으로 소수점 둘째자리 반올림한다")
+        void buyRateRoundsHalfUp() {
+            // Arrange: 1345.50 * 1.05 = 1412.775 → HALF_UP → 1412.78
+            KoreaEximApiResponse response = createApiResponse("USD", "1,345.50");
+            given(koreaEximClient.fetchRates(any())).willReturn(List.of(response));
+            given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // Act
+            exchangeRateService.fetchAndSaveRates();
+
+            // Assert
+            ExchangeRateHistory rate = exchangeRateService.getLatestRate(Currency.USD);
+            assertThat(rate.getBuyRate()).isEqualByComparingTo("1412.78");
+        }
+
+        @Test
+        @DisplayName("sellRate는 HALF_UP으로 소수점 둘째자리 반올림한다")
+        void sellRateRoundsHalfUp() {
+            // Arrange: 1345.50 * 0.95 = 1278.225 → HALF_UP → 1278.23
+            KoreaEximApiResponse response = createApiResponse("USD", "1,345.50");
+            given(koreaEximClient.fetchRates(any())).willReturn(List.of(response));
+            given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // Act
+            exchangeRateService.fetchAndSaveRates();
+
+            // Assert
+            ExchangeRateHistory rate = exchangeRateService.getLatestRate(Currency.USD);
+            assertThat(rate.getSellRate()).isEqualByComparingTo("1278.23");
+        }
+
+        @Test
+        @DisplayName("HALF_UP 경계값: 소수점 셋째자리가 5일 때 올림한다")
+        void halfUpEdgeCase() {
+            // Arrange: 1345.55 * 1.05 = 1412.8275 → HALF_UP → 1412.83
+            KoreaEximApiResponse response = createApiResponse("USD", "1,345.55");
+            given(koreaEximClient.fetchRates(any())).willReturn(List.of(response));
+            given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // Act
+            exchangeRateService.fetchAndSaveRates();
+
+            // Assert
+            ExchangeRateHistory rate = exchangeRateService.getLatestRate(Currency.USD);
+            assertThat(rate.getBuyRate()).isEqualByComparingTo("1412.83");
+        }
+
+        @Test
+        @DisplayName("쉼표가 포함된 환율 문자열을 올바르게 파싱한다")
+        void parsesCommaFormattedRate() {
+            // Arrange
+            KoreaEximApiResponse response = createApiResponse("EUR", "1,478.90");
+            given(koreaEximClient.fetchRates(any())).willReturn(List.of(response));
+            given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // Act
+            exchangeRateService.fetchAndSaveRates();
+
+            // Assert
+            ExchangeRateHistory rate = exchangeRateService.getLatestRate(Currency.EUR);
+            assertThat(rate.getTradeStanRate()).isEqualByComparingTo("1478.90");
+        }
+
+        @Test
+        @DisplayName("JPY(100) 형식의 통화코드를 올바르게 파싱한다")
+        void parsesJpyWithUnitNotation() {
+            // Arrange
+            KoreaEximApiResponse response = createApiResponse("JPY(100)", "917.44");
+            given(koreaEximClient.fetchRates(any())).willReturn(List.of(response));
+            given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // Act
+            exchangeRateService.fetchAndSaveRates();
+
+            // Assert
+            ExchangeRateHistory rate = exchangeRateService.getLatestRate(Currency.JPY);
+            assertThat(rate.getTradeStanRate()).isEqualByComparingTo("917.44");
+        }
+
+        @Test
+        @DisplayName("대상 통화(USD, JPY, CNY, EUR)만 저장한다")
+        void savesOnlyTargetCurrencies() {
+            // Arrange
+            KoreaEximApiResponse usd = createApiResponse("USD", "1,345.50");
+            KoreaEximApiResponse gbp = createApiResponse("GBP", "1,700.00");
+            given(koreaEximClient.fetchRates(any())).willReturn(List.of(usd, gbp));
+            given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // Act
+            exchangeRateService.fetchAndSaveRates();
+
+            // Assert: GBP는 조회되지 않아야 함
+            assertThatThrownBy(() -> exchangeRateService.getLatestRate(Currency.KRW))
+                    .isInstanceOf(RateNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("빈 응답일 때 이전 영업일로 재시도한다")
+        void retriesPreviousBusinessDay() {
+            // Arrange: 첫 호출 빈 배열, 두 번째 호출 데이터 반환
+            KoreaEximApiResponse response = createApiResponse("USD", "1,345.50");
+            given(koreaEximClient.fetchRates(any()))
+                    .willReturn(List.of())
+                    .willReturn(List.of(response));
+            given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // Act
+            exchangeRateService.fetchAndSaveRates();
+
+            // Assert
+            ExchangeRateHistory rate = exchangeRateService.getLatestRate(Currency.USD);
+            assertThat(rate).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("환율 조회")
+    class GetLatestRates {
+
+        @Test
+        @DisplayName("캐시가 비어있으면 RateNotFoundException을 던진다")
+        void throwsWhenCacheEmpty() {
+            assertThatThrownBy(() -> exchangeRateService.getLatestAll())
+                    .isInstanceOf(RateNotFoundException.class)
+                    .hasMessageContaining("수집된 환율 데이터가 없습니다");
+        }
+
+        @Test
+        @DisplayName("특정 통화 환율이 없으면 RateNotFoundException을 던진다")
+        void throwsWhenCurrencyNotFound() {
+            assertThatThrownBy(() -> exchangeRateService.getLatest(Currency.USD))
+                    .isInstanceOf(RateNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("수집된 환율을 ExchangeRateResponse로 변환하여 반환한다")
+        void returnsResponseAfterFetch() {
+            // Arrange
+            KoreaEximApiResponse response = createApiResponse("USD", "1,345.50");
+            given(koreaEximClient.fetchRates(any())).willReturn(List.of(response));
+            given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            exchangeRateService.fetchAndSaveRates();
+
+            // Act
+            ExchangeRateResponse result = exchangeRateService.getLatest(Currency.USD);
+
+            // Assert
+            assertThat(result.getCurrency()).isEqualTo("USD");
+            assertThat(result.getTradeStanRate()).isEqualByComparingTo("1345.50");
+            assertThat(result.getBuyRate()).isEqualByComparingTo("1412.78");
+            assertThat(result.getSellRate()).isEqualByComparingTo("1278.23");
+        }
+
+        @Test
+        @DisplayName("전체 환율 조회 시 수집된 모든 통화를 반환한다")
+        void returnsAllCurrencies() {
+            // Arrange
+            KoreaEximApiResponse usd = createApiResponse("USD", "1,345.50");
+            KoreaEximApiResponse eur = createApiResponse("EUR", "1,478.90");
+            given(koreaEximClient.fetchRates(any())).willReturn(List.of(usd, eur));
+            given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            exchangeRateService.fetchAndSaveRates();
+
+            // Act
+            List<ExchangeRateResponse> results = exchangeRateService.getLatestAll();
+
+            // Assert
+            assertThat(results).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("캐시 워밍")
+    class WarmUpCache {
+
+        @Test
+        @DisplayName("서버 시작 시 DB에서 최신 환율을 캐시에 로드한다")
+        void loadsFromDbOnStartup() {
+            // Arrange
+            ExchangeRateHistory usdRate = ExchangeRateHistory.builder()
+                    .currency(Currency.USD)
+                    .tradeStanRate(new BigDecimal("1345.50"))
+                    .buyRate(new BigDecimal("1412.78"))
+                    .sellRate(new BigDecimal("1278.23"))
+                    .dateTime(java.time.LocalDateTime.now())
+                    .build();
+
+            given(repository.findTopByCurrencyOrderByDateTimeDesc(Currency.USD))
+                    .willReturn(Optional.of(usdRate));
+            given(repository.findTopByCurrencyOrderByDateTimeDesc(Currency.JPY))
+                    .willReturn(Optional.empty());
+            given(repository.findTopByCurrencyOrderByDateTimeDesc(Currency.CNY))
+                    .willReturn(Optional.empty());
+            given(repository.findTopByCurrencyOrderByDateTimeDesc(Currency.EUR))
+                    .willReturn(Optional.empty());
+
+            // Act
+            exchangeRateService.warmUpCache();
+
+            // Assert
+            ExchangeRateHistory result = exchangeRateService.getLatestRate(Currency.USD);
+            assertThat(result.getBuyRate()).isEqualByComparingTo("1412.78");
+        }
+    }
+
+    private KoreaEximApiResponse createApiResponse(String curUnit, String dealBasR) {
+        try {
+            KoreaEximApiResponse response = new KoreaEximApiResponse();
+            var curUnitField = KoreaEximApiResponse.class.getDeclaredField("curUnit");
+            curUnitField.setAccessible(true);
+            curUnitField.set(response, curUnit);
+
+            var dealBasRField = KoreaEximApiResponse.class.getDeclaredField("dealBasR");
+            dealBasRField.setAccessible(true);
+            dealBasRField.set(response, dealBasR);
+
+            var resultField = KoreaEximApiResponse.class.getDeclaredField("result");
+            resultField.setAccessible(true);
+            resultField.set(response, 1);
+
+            return response;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 한국수출입은행 API에서 1분 주기로 환율 수집
- buyRate(x1.05), sellRate(x0.95) 계산 및 저장
- ConcurrentHashMap 캐시로 O(1) 환율 조회
- GET /exchange-rate/latest, GET /exchange-rate/latest/{currency}

## TDD 흐름
1. **RED**: ExchangeRateServiceTest 14개 테스트 작성 → 전체 실패 (Service 미구현)
2. **GREEN**: Service, Client, Scheduler, Controller 구현 → 17개 전체 통과

## 설계 결정

### RestClient 선택 (RestTemplate, WebClient 대비)
Spring 6.1+에서 RestTemplate의 공식 후속으로 도입된 RestClient를 채택. 스케줄러는 동기 실행이므로 WebClient의 비동기 장점이 불필요하고, spring-boot-starter-web에 내장되어 추가 의존성 없음.

### ConcurrentHashMap 캐시 (DB 매번 조회 대비)
환율은 1분마다 갱신되며, 그 사이 모든 조회/주문은 같은 환율 사용. Map에서 O(1) 반환. @PostConstruct에서 DB 최신 데이터 로드로 서버 재시작 대응.

### fixedDelay (fixedRate 대비)
외부 API + 최대 7일 retry 포함 → 실행 시간 길어질 수 있어 겹침 방지를 위해 fixedDelay 선택.

### KoreaEximClient 인터페이스 분리
테스트에서 mock이 용이하도록 인터페이스로 분리. 실제 HTTP 호출은 KoreaEximClientImpl에서 담당.

## Test Plan
- [x] buyRate/sellRate 계산 정확성 (HALF_UP)
- [x] 쉼표 포함 환율 문자열 파싱
- [x] JPY(100) 통화코드 파싱
- [x] 대상 통화만 저장 (GBP 등 비대상 제외)
- [x] 빈 응답 시 이전 영업일 retry
- [x] 캐시 빈 상태 예외 처리
- [x] 캐시 워밍 동작
- [x] Repository 최신순 조회

closes #3