### PR TITLE
feat: 외화 주문 기능 구현

### DIFF
--- a/src/main/java/com/forex/order/order/controller/OrderController.java
+++ b/src/main/java/com/forex/order/order/controller/OrderController.java
@@ -1,0 +1,37 @@
+package com.forex.order.order.controller;
+
+import com.forex.order.common.ApiResponse;
+import com.forex.order.order.dto.OrderRequest;
+import com.forex.order.order.dto.OrderResponse;
+import com.forex.order.order.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/order")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<OrderResponse>> createOrder(
+            @Valid @RequestBody OrderRequest request) {
+        OrderResponse response = orderService.createOrder(request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<ApiResponse<List<OrderResponse>>> getOrders() {
+        List<OrderResponse> orders = orderService.getOrders();
+        return ResponseEntity.ok(ApiResponse.ok(orders));
+    }
+}

--- a/src/main/java/com/forex/order/order/dto/OrderRequest.java
+++ b/src/main/java/com/forex/order/order/dto/OrderRequest.java
@@ -1,0 +1,27 @@
+package com.forex.order.order.dto;
+
+import com.forex.order.common.Currency;
+import com.forex.order.common.OrderType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderRequest {
+
+    @NotNull(message = "주문 유형은 필수입니다")
+    private OrderType orderType;
+
+    @NotNull(message = "통화는 필수입니다")
+    private Currency currency;
+
+    @NotNull(message = "금액은 필수입니다")
+    @Positive(message = "금액은 양수여야 합니다")
+    private BigDecimal forexAmount;
+}

--- a/src/main/java/com/forex/order/order/dto/OrderResponse.java
+++ b/src/main/java/com/forex/order/order/dto/OrderResponse.java
@@ -1,0 +1,22 @@
+package com.forex.order.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OrderResponse {
+
+    private Long id;
+    private BigDecimal fromAmount;
+    private String fromCurrency;
+    private BigDecimal toAmount;
+    private String toCurrency;
+    private BigDecimal tradeRate;
+    private LocalDateTime dateTime;
+}

--- a/src/main/java/com/forex/order/order/service/OrderService.java
+++ b/src/main/java/com/forex/order/order/service/OrderService.java
@@ -1,12 +1,22 @@
 package com.forex.order.order.service;
 
+import com.forex.order.common.Currency;
+import com.forex.order.common.OrderType;
+import com.forex.order.common.exception.InvalidCurrencyException;
+import com.forex.order.common.exception.RateNotAvailableException;
+import com.forex.order.exchangerate.entity.ExchangeRateHistory;
 import com.forex.order.exchangerate.service.ExchangeRateService;
 import com.forex.order.order.dto.OrderRequest;
 import com.forex.order.order.dto.OrderResponse;
+import com.forex.order.order.entity.ForexOrder;
 import com.forex.order.order.repository.ForexOrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -16,13 +26,77 @@ public class OrderService {
     private final ForexOrderRepository orderRepository;
     private final ExchangeRateService exchangeRateService;
 
+    @Transactional
     public OrderResponse createOrder(OrderRequest request) {
-        // TODO: 구현 예정
-        return null;
+        Currency currency = request.getCurrency();
+        validateNotKrw(currency);
+
+        ExchangeRateHistory rate;
+        try {
+            rate = exchangeRateService.getLatestRate(currency);
+        } catch (Exception e) {
+            throw new RateNotAvailableException(currency + " 통화의 환율이 준비되지 않았습니다");
+        }
+
+        BigDecimal tradeRate = (request.getOrderType() == OrderType.BUY)
+                ? rate.getBuyRate()
+                : rate.getSellRate();
+
+        BigDecimal krwAmount = request.getForexAmount()
+                .multiply(tradeRate)
+                .divide(currency.getUnit(), 0, RoundingMode.FLOOR);
+
+        ForexOrder order = buildOrder(request, currency, tradeRate, krwAmount);
+        ForexOrder saved = orderRepository.save(order);
+
+        return toResponse(saved);
     }
 
+    @Transactional(readOnly = true)
     public List<OrderResponse> getOrders() {
-        // TODO: 구현 예정
-        return List.of();
+        return orderRepository.findAllByOrderByDateTimeDesc().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private void validateNotKrw(Currency currency) {
+        if (currency == Currency.KRW) {
+            throw new InvalidCurrencyException("KRW는 외화 주문 대상이 아닙니다");
+        }
+    }
+
+    private ForexOrder buildOrder(OrderRequest request, Currency currency,
+                                  BigDecimal tradeRate, BigDecimal krwAmount) {
+        if (request.getOrderType() == OrderType.BUY) {
+            return ForexOrder.builder()
+                    .fromAmount(krwAmount)
+                    .fromCurrency(Currency.KRW)
+                    .toAmount(request.getForexAmount())
+                    .toCurrency(currency)
+                    .tradeRate(tradeRate)
+                    .dateTime(LocalDateTime.now())
+                    .build();
+        }
+
+        return ForexOrder.builder()
+                .fromAmount(request.getForexAmount())
+                .fromCurrency(currency)
+                .toAmount(krwAmount)
+                .toCurrency(Currency.KRW)
+                .tradeRate(tradeRate)
+                .dateTime(LocalDateTime.now())
+                .build();
+    }
+
+    private OrderResponse toResponse(ForexOrder order) {
+        return OrderResponse.builder()
+                .id(order.getId())
+                .fromAmount(order.getFromAmount())
+                .fromCurrency(order.getFromCurrency().name())
+                .toAmount(order.getToAmount())
+                .toCurrency(order.getToCurrency().name())
+                .tradeRate(order.getTradeRate())
+                .dateTime(order.getDateTime())
+                .build();
     }
 }

--- a/src/main/java/com/forex/order/order/service/OrderService.java
+++ b/src/main/java/com/forex/order/order/service/OrderService.java
@@ -1,0 +1,28 @@
+package com.forex.order.order.service;
+
+import com.forex.order.exchangerate.service.ExchangeRateService;
+import com.forex.order.order.dto.OrderRequest;
+import com.forex.order.order.dto.OrderResponse;
+import com.forex.order.order.repository.ForexOrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final ForexOrderRepository orderRepository;
+    private final ExchangeRateService exchangeRateService;
+
+    public OrderResponse createOrder(OrderRequest request) {
+        // TODO: 구현 예정
+        return null;
+    }
+
+    public List<OrderResponse> getOrders() {
+        // TODO: 구현 예정
+        return List.of();
+    }
+}

--- a/src/test/java/com/forex/order/order/repository/ForexOrderRepositoryTest.java
+++ b/src/test/java/com/forex/order/order/repository/ForexOrderRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.forex.order.order.repository;
+
+import com.forex.order.common.Currency;
+import com.forex.order.order.entity.ForexOrder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ForexOrderRepositoryTest {
+
+    @Autowired
+    private ForexOrderRepository forexOrderRepository;
+
+    @Test
+    @DisplayName("주문 목록을 최신순(dateTime DESC)으로 반환한다")
+    void returnsOrdersByDateTimeDesc() {
+        // Arrange
+        ForexOrder older = ForexOrder.builder()
+                .fromAmount(new BigDecimal("141278"))
+                .fromCurrency(Currency.KRW)
+                .toAmount(new BigDecimal("100"))
+                .toCurrency(Currency.USD)
+                .tradeRate(new BigDecimal("1412.78"))
+                .dateTime(LocalDateTime.of(2026, 4, 24, 10, 0))
+                .build();
+
+        ForexOrder newer = ForexOrder.builder()
+                .fromAmount(new BigDecimal("127823"))
+                .fromCurrency(Currency.USD)
+                .toAmount(new BigDecimal("100"))
+                .toCurrency(Currency.KRW)
+                .tradeRate(new BigDecimal("1278.23"))
+                .dateTime(LocalDateTime.of(2026, 4, 24, 14, 0))
+                .build();
+
+        forexOrderRepository.save(older);
+        forexOrderRepository.save(newer);
+
+        // Act
+        List<ForexOrder> result = forexOrderRepository.findAllByOrderByDateTimeDesc();
+
+        // Assert
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getDateTime()).isAfter(result.get(1).getDateTime());
+    }
+
+    @Test
+    @DisplayName("주문이 없으면 빈 목록을 반환한다")
+    void returnsEmptyListWhenNoOrders() {
+        List<ForexOrder> result = forexOrderRepository.findAllByOrderByDateTimeDesc();
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/forex/order/order/service/OrderServiceTest.java
+++ b/src/test/java/com/forex/order/order/service/OrderServiceTest.java
@@ -1,0 +1,226 @@
+package com.forex.order.order.service;
+
+import com.forex.order.common.Currency;
+import com.forex.order.common.OrderType;
+import com.forex.order.common.exception.InvalidCurrencyException;
+import com.forex.order.common.exception.RateNotAvailableException;
+import com.forex.order.common.exception.RateNotFoundException;
+import com.forex.order.exchangerate.entity.ExchangeRateHistory;
+import com.forex.order.exchangerate.service.ExchangeRateService;
+import com.forex.order.order.dto.OrderRequest;
+import com.forex.order.order.dto.OrderResponse;
+import com.forex.order.order.entity.ForexOrder;
+import com.forex.order.order.repository.ForexOrderRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private ForexOrderRepository orderRepository;
+
+    @Mock
+    private ExchangeRateService exchangeRateService;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Nested
+    @DisplayName("매수 주문 (BUY: KRW -> 외화)")
+    class BuyOrder {
+
+        @Test
+        @DisplayName("USD 100 매수 시 buyRate를 적용하여 KRW 금액을 계산한다")
+        void calculatesKrwWithBuyRate() {
+            // Arrange: 100 USD, buyRate 1412.78 → KRW = 100 * 1412.78 / 1 = 141278
+            givenRate(Currency.USD, "1412.78", "1278.23");
+            givenSavedOrder();
+            OrderRequest request = new OrderRequest(OrderType.BUY, Currency.USD, new BigDecimal("100"));
+
+            // Act
+            OrderResponse response = orderService.createOrder(request);
+
+            // Assert
+            assertThat(response.getFromCurrency()).isEqualTo("KRW");
+            assertThat(response.getFromAmount()).isEqualByComparingTo("141278");
+            assertThat(response.getToCurrency()).isEqualTo("USD");
+            assertThat(response.getToAmount()).isEqualByComparingTo("100");
+            assertThat(response.getTradeRate()).isEqualByComparingTo("1412.78");
+        }
+
+        @Test
+        @DisplayName("KRW 금액의 소수점을 버림(FLOOR)한다")
+        void floorsKrwAmount() {
+            // Arrange: 33 USD, buyRate 1412.78 → 33 * 1412.78 = 46621.74 → FLOOR → 46621
+            givenRate(Currency.USD, "1412.78", "1278.23");
+            givenSavedOrder();
+            OrderRequest request = new OrderRequest(OrderType.BUY, Currency.USD, new BigDecimal("33"));
+
+            // Act
+            OrderResponse response = orderService.createOrder(request);
+
+            // Assert
+            assertThat(response.getFromAmount()).isEqualByComparingTo("46621");
+        }
+
+        @Test
+        @DisplayName("JPY 매수 시 100엔 단위(unit=100)를 적용한다")
+        void appliesJpyUnit() {
+            // Arrange: 1000 JPY, buyRate 963.31 → 1000 * 963.31 / 100 = 9633.1 → FLOOR → 9633
+            givenRate(Currency.JPY, "963.31", "871.57");
+            givenSavedOrder();
+            OrderRequest request = new OrderRequest(OrderType.BUY, Currency.JPY, new BigDecimal("1000"));
+
+            // Act
+            OrderResponse response = orderService.createOrder(request);
+
+            // Assert
+            assertThat(response.getFromAmount()).isEqualByComparingTo("9633");
+        }
+    }
+
+    @Nested
+    @DisplayName("매도 주문 (SELL: 외화 -> KRW)")
+    class SellOrder {
+
+        @Test
+        @DisplayName("USD 100 매도 시 sellRate를 적용하여 KRW 금액을 계산한다")
+        void calculatesKrwWithSellRate() {
+            // Arrange: 100 USD, sellRate 1278.23 → KRW = 100 * 1278.23 / 1 = 127823
+            givenRate(Currency.USD, "1412.78", "1278.23");
+            givenSavedOrder();
+            OrderRequest request = new OrderRequest(OrderType.SELL, Currency.USD, new BigDecimal("100"));
+
+            // Act
+            OrderResponse response = orderService.createOrder(request);
+
+            // Assert
+            assertThat(response.getFromCurrency()).isEqualTo("USD");
+            assertThat(response.getFromAmount()).isEqualByComparingTo("100");
+            assertThat(response.getToCurrency()).isEqualTo("KRW");
+            assertThat(response.getToAmount()).isEqualByComparingTo("127823");
+            assertThat(response.getTradeRate()).isEqualByComparingTo("1278.23");
+        }
+
+        @Test
+        @DisplayName("JPY 매도 시 100엔 단위(unit=100)를 적용한다")
+        void appliesJpyUnit() {
+            // Arrange: 5000 JPY, sellRate 871.57 → 5000 * 871.57 / 100 = 43578.5 → FLOOR → 43578
+            givenRate(Currency.JPY, "963.31", "871.57");
+            givenSavedOrder();
+            OrderRequest request = new OrderRequest(OrderType.SELL, Currency.JPY, new BigDecimal("5000"));
+
+            // Act
+            OrderResponse response = orderService.createOrder(request);
+
+            // Assert
+            assertThat(response.getToAmount()).isEqualByComparingTo("43578");
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 검증")
+    class Validation {
+
+        @Test
+        @DisplayName("KRW 통화로 주문하면 InvalidCurrencyException을 던진다")
+        void rejectsKrwOrder() {
+            OrderRequest request = new OrderRequest(OrderType.BUY, Currency.KRW, new BigDecimal("100"));
+
+            assertThatThrownBy(() -> orderService.createOrder(request))
+                    .isInstanceOf(InvalidCurrencyException.class)
+                    .hasMessageContaining("KRW");
+        }
+
+        @Test
+        @DisplayName("환율이 없으면 RateNotAvailableException을 던진다")
+        void rejectsWhenNoRate() {
+            given(exchangeRateService.getLatestRate(Currency.USD))
+                    .willThrow(new RateNotFoundException("USD 환율 없음"));
+
+            OrderRequest request = new OrderRequest(OrderType.BUY, Currency.USD, new BigDecimal("100"));
+
+            assertThatThrownBy(() -> orderService.createOrder(request))
+                    .isInstanceOf(RateNotAvailableException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 목록 조회")
+    class GetOrders {
+
+        @Test
+        @DisplayName("주문이 없으면 빈 목록을 반환한다")
+        void returnsEmptyList() {
+            given(orderRepository.findAllByOrderByDateTimeDesc()).willReturn(List.of());
+
+            List<OrderResponse> result = orderService.getOrders();
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("주문 목록을 OrderResponse로 변환하여 반환한다")
+        void returnsOrderResponses() {
+            ForexOrder order = ForexOrder.builder()
+                    .id(1L)
+                    .fromAmount(new BigDecimal("141278"))
+                    .fromCurrency(Currency.KRW)
+                    .toAmount(new BigDecimal("100"))
+                    .toCurrency(Currency.USD)
+                    .tradeRate(new BigDecimal("1412.78"))
+                    .dateTime(LocalDateTime.now())
+                    .build();
+
+            given(orderRepository.findAllByOrderByDateTimeDesc()).willReturn(List.of(order));
+
+            List<OrderResponse> result = orderService.getOrders();
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getFromCurrency()).isEqualTo("KRW");
+            assertThat(result.get(0).getToCurrency()).isEqualTo("USD");
+        }
+    }
+
+    private void givenRate(Currency currency, String buyRate, String sellRate) {
+        ExchangeRateHistory rate = ExchangeRateHistory.builder()
+                .currency(currency)
+                .tradeStanRate(new BigDecimal("1345.50"))
+                .buyRate(new BigDecimal(buyRate))
+                .sellRate(new BigDecimal(sellRate))
+                .dateTime(LocalDateTime.now())
+                .build();
+
+        given(exchangeRateService.getLatestRate(currency)).willReturn(rate);
+    }
+
+    private void givenSavedOrder() {
+        given(orderRepository.save(any(ForexOrder.class))).willAnswer(invocation -> {
+            ForexOrder order = invocation.getArgument(0);
+            return ForexOrder.builder()
+                    .id(1L)
+                    .fromAmount(order.getFromAmount())
+                    .fromCurrency(order.getFromCurrency())
+                    .toAmount(order.getToAmount())
+                    .toCurrency(order.getToCurrency())
+                    .tradeRate(order.getTradeRate())
+                    .dateTime(order.getDateTime())
+                    .build();
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- POST /order: 외화 매수/매도 주문 생성
- GET /order/list: 주문 내역 최신순 조회
- KRW 금액 소수점 버림(FLOOR), JPY 100엔 단위 처리

## TDD 흐름
1. **RED**: OrderServiceTest 9개, ForexOrderRepositoryTest 2개 작성 → 9개 실패
2. **GREEN**: OrderService, OrderController 구현 → 28개 전체 통과

## 설계 결정

### currency.getUnit()으로 JPY 분기 제거
모든 통화에 `krwAmount = forexAmount * rate / currency.getUnit()` 동일 계산식을 적용합니다.
if문으로 JPY를 분기하는 대신, Currency Enum의 unit 필드(USD=1, JPY=100)를 활용하여 코드 경로를 단일화했습니다. 새로운 100단위 통화(IDR 등) 추가 시 Enum에 값만 추가하면 됩니다.

### 검증 계층 분리
- @Valid(Controller): 형식 검증 — @NotNull, @Positive로 빈 값/음수 차단
- Service: 비즈니스 검증 — KRW 주문 거부, 환율 존재 여부 확인

형식 검증을 Controller에서 처리하면 Service까지 호출하지 않아 불필요한 DB 접근을 방지합니다.

### @Transactional + 캐시 조회
환율은 ConcurrentHashMap 캐시에서 읽으므로 DB 락이 발생하지 않습니다. save()에 트랜잭션이 필요하므로 메서드 레벨 @Transactional을 유지하되, 실질적 성능 이슈는 없습니다.

## Test Plan
- [x] USD 매수 KRW 계산 (buyRate 적용)
- [x] USD 매도 KRW 계산 (sellRate 적용)
- [x] KRW FLOOR (소수점 버림)
- [x] JPY unit=100 적용 (매수/매도)
- [x] KRW 통화 주문 거부
- [x] 환율 미존재 시 예외
- [x] 빈 주문 목록
- [x] 주문 목록 반환
- [x] 주문 최신순 정렬 (Repository)

closes #5