### PR TITLE
feat: Swagger/OpenAPI 문서화 설정

### DIFF
--- a/src/main/java/com/forex/order/config/OpenApiConfig.java
+++ b/src/main/java/com/forex/order/config/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package com.forex.order.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("외환 주문 시스템 API")
+                        .description("실시간 환율 기반 외환 주문 시스템")
+                        .version("1.0.0"));
+    }
+}


### PR DESCRIPTION
## Summary
- OpenApiConfig 추가: API 제목, 설명, 버전 정의
- Swagger UI: /swagger-ui.html 에서 API 문서 확인 가능

## 설계 결정

### SpringDoc OpenAPI 2.x 선택
Springfox는 Spring Boot 3.x를 지원하지 않아 사실상 deprecated 상태입니다.
SpringDoc은 Spring Boot 3.x + Jakarta EE를 공식 지원하며, `springdoc-openapi-starter-webmvc-ui` 하나로 Swagger UI가 포함됩니다.

closes #7