### PR TITLE
fix: 과제 API 명세에 맞게 요청/응답 구조 수정

### DIFF
--- a/src/main/java/com/forex/order/common/OrderType.java
+++ b/src/main/java/com/forex/order/common/OrderType.java
@@ -1,7 +1,0 @@
-package com.forex.order.common;
-
-public enum OrderType {
-
-    BUY,
-    SELL
-}

--- a/src/main/java/com/forex/order/exchangerate/controller/ExchangeRateController.java
+++ b/src/main/java/com/forex/order/exchangerate/controller/ExchangeRateController.java
@@ -2,6 +2,7 @@ package com.forex.order.exchangerate.controller;
 
 import com.forex.order.common.ApiResponse;
 import com.forex.order.common.Currency;
+import com.forex.order.exchangerate.dto.ExchangeRateListResponse;
 import com.forex.order.exchangerate.dto.ExchangeRateResponse;
 import com.forex.order.exchangerate.service.ExchangeRateService;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +22,9 @@ public class ExchangeRateController {
     private final ExchangeRateService exchangeRateService;
 
     @GetMapping("/latest")
-    public ResponseEntity<ApiResponse<List<ExchangeRateResponse>>> getLatestAll() {
+    public ResponseEntity<ApiResponse<ExchangeRateListResponse>> getLatestAll() {
         List<ExchangeRateResponse> rates = exchangeRateService.getLatestAll();
-        return ResponseEntity.ok(ApiResponse.ok(rates));
+        return ResponseEntity.ok(ApiResponse.ok(new ExchangeRateListResponse(rates)));
     }
 
     @GetMapping("/latest/{currency}")

--- a/src/main/java/com/forex/order/exchangerate/dto/ExchangeRateListResponse.java
+++ b/src/main/java/com/forex/order/exchangerate/dto/ExchangeRateListResponse.java
@@ -1,0 +1,13 @@
+package com.forex.order.exchangerate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ExchangeRateListResponse {
+
+    private List<ExchangeRateResponse> exchangeRateList;
+}

--- a/src/main/java/com/forex/order/exchangerate/service/ExchangeRateService.java
+++ b/src/main/java/com/forex/order/exchangerate/service/ExchangeRateService.java
@@ -19,6 +19,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -33,9 +34,14 @@ public class ExchangeRateService {
     private static final Set<Currency> TARGET_CURRENCIES = Set.of(
             Currency.USD, Currency.JPY, Currency.CNY, Currency.EUR
     );
+    private static final BigDecimal RANDOM_VARIATION_RANGE = new BigDecimal("0.02");
+    private final Random random = new Random();
 
     private final ExchangeRateHistoryRepository repository;
     private final KoreaEximClient koreaEximClient;
+
+    @org.springframework.beans.factory.annotation.Value("${exchange-rate.random-variation:true}")
+    private boolean randomVariationEnabled = true;
     private final ConcurrentHashMap<Currency, ExchangeRateHistory> latestRates = new ConcurrentHashMap<>();
 
     @PostConstruct
@@ -98,7 +104,7 @@ public class ExchangeRateService {
                 continue;
             }
 
-            BigDecimal tradeStanRate = parseRate(response.getDealBasR());
+            BigDecimal tradeStanRate = applyRandomVariation(parseRate(response.getDealBasR()));
             BigDecimal buyRate = tradeStanRate.multiply(BUY_SPREAD_RATE)
                     .setScale(2, RoundingMode.HALF_UP);
             BigDecimal sellRate = tradeStanRate.multiply(SELL_SPREAD_RATE)
@@ -117,6 +123,15 @@ public class ExchangeRateService {
         }
 
         log.info("환율 수집 완료: {}개 통화 갱신", latestRates.size());
+    }
+
+    private BigDecimal applyRandomVariation(BigDecimal rate) {
+        if (!randomVariationEnabled) {
+            return rate;
+        }
+        double variation = (random.nextDouble() * 2 - 1) * RANDOM_VARIATION_RANGE.doubleValue();
+        BigDecimal factor = BigDecimal.ONE.add(BigDecimal.valueOf(variation));
+        return rate.multiply(factor).setScale(2, RoundingMode.HALF_UP);
     }
 
     private Currency parseCurrency(String curUnit) {

--- a/src/main/java/com/forex/order/order/controller/OrderController.java
+++ b/src/main/java/com/forex/order/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.forex.order.order.controller;
 
 import com.forex.order.common.ApiResponse;
+import com.forex.order.order.dto.OrderListResponse;
 import com.forex.order.order.dto.OrderRequest;
 import com.forex.order.order.dto.OrderResponse;
 import com.forex.order.order.service.OrderService;
@@ -30,8 +31,8 @@ public class OrderController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<ApiResponse<List<OrderResponse>>> getOrders() {
+    public ResponseEntity<ApiResponse<OrderListResponse>> getOrders() {
         List<OrderResponse> orders = orderService.getOrders();
-        return ResponseEntity.ok(ApiResponse.ok(orders));
+        return ResponseEntity.ok(ApiResponse.ok(new OrderListResponse(orders)));
     }
 }

--- a/src/main/java/com/forex/order/order/dto/OrderListResponse.java
+++ b/src/main/java/com/forex/order/order/dto/OrderListResponse.java
@@ -1,0 +1,13 @@
+package com.forex.order.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class OrderListResponse {
+
+    private List<OrderResponse> orderList;
+}

--- a/src/main/java/com/forex/order/order/dto/OrderRequest.java
+++ b/src/main/java/com/forex/order/order/dto/OrderRequest.java
@@ -1,7 +1,6 @@
 package com.forex.order.order.dto;
 
 import com.forex.order.common.Currency;
-import com.forex.order.common.OrderType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
@@ -15,13 +14,13 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 public class OrderRequest {
 
-    @NotNull(message = "주문 유형은 필수입니다")
-    private OrderType orderType;
-
-    @NotNull(message = "통화는 필수입니다")
-    private Currency currency;
-
     @NotNull(message = "금액은 필수입니다")
     @Positive(message = "금액은 양수여야 합니다")
     private BigDecimal forexAmount;
+
+    @NotNull(message = "출발 통화는 필수입니다")
+    private Currency fromCurrency;
+
+    @NotNull(message = "도착 통화는 필수입니다")
+    private Currency toCurrency;
 }

--- a/src/main/java/com/forex/order/order/service/OrderService.java
+++ b/src/main/java/com/forex/order/order/service/OrderService.java
@@ -1,7 +1,6 @@
 package com.forex.order.order.service;
 
 import com.forex.order.common.Currency;
-import com.forex.order.common.OrderType;
 import com.forex.order.common.exception.InvalidCurrencyException;
 import com.forex.order.common.exception.RateNotAvailableException;
 import com.forex.order.exchangerate.entity.ExchangeRateHistory;
@@ -28,25 +27,25 @@ public class OrderService {
 
     @Transactional
     public OrderResponse createOrder(OrderRequest request) {
-        Currency currency = request.getCurrency();
-        validateNotKrw(currency);
+        validateCurrencyPair(request.getFromCurrency(), request.getToCurrency());
+
+        boolean isBuy = request.getFromCurrency() == Currency.KRW;
+        Currency foreignCurrency = isBuy ? request.getToCurrency() : request.getFromCurrency();
 
         ExchangeRateHistory rate;
         try {
-            rate = exchangeRateService.getLatestRate(currency);
+            rate = exchangeRateService.getLatestRate(foreignCurrency);
         } catch (Exception e) {
-            throw new RateNotAvailableException(currency + " 통화의 환율이 준비되지 않았습니다");
+            throw new RateNotAvailableException(foreignCurrency + " 통화의 환율이 준비되지 않았습니다");
         }
 
-        BigDecimal tradeRate = (request.getOrderType() == OrderType.BUY)
-                ? rate.getBuyRate()
-                : rate.getSellRate();
+        BigDecimal tradeRate = isBuy ? rate.getBuyRate() : rate.getSellRate();
 
         BigDecimal krwAmount = request.getForexAmount()
                 .multiply(tradeRate)
-                .divide(currency.getUnit(), 0, RoundingMode.FLOOR);
+                .divide(foreignCurrency.getUnit(), 0, RoundingMode.FLOOR);
 
-        ForexOrder order = buildOrder(request, currency, tradeRate, krwAmount);
+        ForexOrder order = buildOrder(request, tradeRate, krwAmount, isBuy);
         ForexOrder saved = orderRepository.save(order);
 
         return toResponse(saved);
@@ -59,20 +58,30 @@ public class OrderService {
                 .toList();
     }
 
-    private void validateNotKrw(Currency currency) {
-        if (currency == Currency.KRW) {
-            throw new InvalidCurrencyException("KRW는 외화 주문 대상이 아닙니다");
+    private void validateCurrencyPair(Currency from, Currency to) {
+        if (from == to) {
+            throw new InvalidCurrencyException("출발 통화와 도착 통화가 같을 수 없습니다");
+        }
+
+        boolean hasKrw = from == Currency.KRW || to == Currency.KRW;
+        if (!hasKrw) {
+            throw new InvalidCurrencyException("모든 주문은 KRW를 기준으로 진행해야 합니다");
+        }
+
+        Currency foreignCurrency = (from == Currency.KRW) ? to : from;
+        if (foreignCurrency == Currency.KRW) {
+            throw new InvalidCurrencyException("외화 통화를 지정해야 합니다");
         }
     }
 
-    private ForexOrder buildOrder(OrderRequest request, Currency currency,
-                                  BigDecimal tradeRate, BigDecimal krwAmount) {
-        if (request.getOrderType() == OrderType.BUY) {
+    private ForexOrder buildOrder(OrderRequest request, BigDecimal tradeRate,
+                                  BigDecimal krwAmount, boolean isBuy) {
+        if (isBuy) {
             return ForexOrder.builder()
                     .fromAmount(krwAmount)
                     .fromCurrency(Currency.KRW)
                     .toAmount(request.getForexAmount())
-                    .toCurrency(currency)
+                    .toCurrency(request.getToCurrency())
                     .tradeRate(tradeRate)
                     .dateTime(LocalDateTime.now())
                     .build();
@@ -80,7 +89,7 @@ public class OrderService {
 
         return ForexOrder.builder()
                 .fromAmount(request.getForexAmount())
-                .fromCurrency(currency)
+                .fromCurrency(request.getFromCurrency())
                 .toAmount(krwAmount)
                 .toCurrency(Currency.KRW)
                 .tradeRate(tradeRate)

--- a/src/test/java/com/forex/order/exchangerate/service/ExchangeRateServiceTest.java
+++ b/src/test/java/com/forex/order/exchangerate/service/ExchangeRateServiceTest.java
@@ -39,6 +39,13 @@ class ExchangeRateServiceTest {
     @InjectMocks
     private ExchangeRateService exchangeRateService;
 
+    @BeforeEach
+    void setUp() throws Exception {
+        var field = ExchangeRateService.class.getDeclaredField("randomVariationEnabled");
+        field.setAccessible(true);
+        field.set(exchangeRateService, false);
+    }
+
     @Nested
     @DisplayName("환율 수집 및 저장")
     class FetchAndSaveRates {

--- a/src/test/java/com/forex/order/order/service/OrderServiceTest.java
+++ b/src/test/java/com/forex/order/order/service/OrderServiceTest.java
@@ -1,7 +1,6 @@
 package com.forex.order.order.service;
 
 import com.forex.order.common.Currency;
-import com.forex.order.common.OrderType;
 import com.forex.order.common.exception.InvalidCurrencyException;
 import com.forex.order.common.exception.RateNotAvailableException;
 import com.forex.order.common.exception.RateNotFoundException;
@@ -41,26 +40,26 @@ class OrderServiceTest {
     private OrderService orderService;
 
     @Nested
-    @DisplayName("매수 주문 (BUY: KRW -> 외화)")
+    @DisplayName("매수 주문 (KRW -> 외화)")
     class BuyOrder {
 
         @Test
-        @DisplayName("USD 100 매수 시 buyRate를 적용하여 KRW 금액을 계산한다")
+        @DisplayName("USD 200 매수 시 buyRate를 적용하여 KRW 금액을 계산한다")
         void calculatesKrwWithBuyRate() {
-            // Arrange: 100 USD, buyRate 1412.78 → KRW = 100 * 1412.78 / 1 = 141278
-            givenRate(Currency.USD, "1412.78", "1278.23");
+            // Arrange: 200 USD, buyRate 1480.43 → KRW = 200 * 1480.43 / 1 = 296086
+            givenRate(Currency.USD, "1480.43", "1474.47");
             givenSavedOrder();
-            OrderRequest request = new OrderRequest(OrderType.BUY, Currency.USD, new BigDecimal("100"));
+            OrderRequest request = new OrderRequest(new BigDecimal("200"), Currency.KRW, Currency.USD);
 
             // Act
             OrderResponse response = orderService.createOrder(request);
 
             // Assert
             assertThat(response.getFromCurrency()).isEqualTo("KRW");
-            assertThat(response.getFromAmount()).isEqualByComparingTo("141278");
+            assertThat(response.getFromAmount()).isEqualByComparingTo("296086");
             assertThat(response.getToCurrency()).isEqualTo("USD");
-            assertThat(response.getToAmount()).isEqualByComparingTo("100");
-            assertThat(response.getTradeRate()).isEqualByComparingTo("1412.78");
+            assertThat(response.getToAmount()).isEqualByComparingTo("200");
+            assertThat(response.getTradeRate()).isEqualByComparingTo("1480.43");
         }
 
         @Test
@@ -69,7 +68,7 @@ class OrderServiceTest {
             // Arrange: 33 USD, buyRate 1412.78 → 33 * 1412.78 = 46621.74 → FLOOR → 46621
             givenRate(Currency.USD, "1412.78", "1278.23");
             givenSavedOrder();
-            OrderRequest request = new OrderRequest(OrderType.BUY, Currency.USD, new BigDecimal("33"));
+            OrderRequest request = new OrderRequest(new BigDecimal("33"), Currency.KRW, Currency.USD);
 
             // Act
             OrderResponse response = orderService.createOrder(request);
@@ -84,7 +83,7 @@ class OrderServiceTest {
             // Arrange: 1000 JPY, buyRate 963.31 → 1000 * 963.31 / 100 = 9633.1 → FLOOR → 9633
             givenRate(Currency.JPY, "963.31", "871.57");
             givenSavedOrder();
-            OrderRequest request = new OrderRequest(OrderType.BUY, Currency.JPY, new BigDecimal("1000"));
+            OrderRequest request = new OrderRequest(new BigDecimal("1000"), Currency.KRW, Currency.JPY);
 
             // Act
             OrderResponse response = orderService.createOrder(request);
@@ -95,26 +94,26 @@ class OrderServiceTest {
     }
 
     @Nested
-    @DisplayName("매도 주문 (SELL: 외화 -> KRW)")
+    @DisplayName("매도 주문 (외화 -> KRW)")
     class SellOrder {
 
         @Test
-        @DisplayName("USD 100 매도 시 sellRate를 적용하여 KRW 금액을 계산한다")
+        @DisplayName("USD 133 매도 시 sellRate를 적용하여 KRW 금액을 계산한다")
         void calculatesKrwWithSellRate() {
-            // Arrange: 100 USD, sellRate 1278.23 → KRW = 100 * 1278.23 / 1 = 127823
-            givenRate(Currency.USD, "1412.78", "1278.23");
+            // Arrange: 133 USD, sellRate 1474.47 → KRW = 133 * 1474.47 / 1 = 196104.51 → FLOOR → 196104
+            givenRate(Currency.USD, "1480.43", "1474.47");
             givenSavedOrder();
-            OrderRequest request = new OrderRequest(OrderType.SELL, Currency.USD, new BigDecimal("100"));
+            OrderRequest request = new OrderRequest(new BigDecimal("133"), Currency.USD, Currency.KRW);
 
             // Act
             OrderResponse response = orderService.createOrder(request);
 
             // Assert
             assertThat(response.getFromCurrency()).isEqualTo("USD");
-            assertThat(response.getFromAmount()).isEqualByComparingTo("100");
+            assertThat(response.getFromAmount()).isEqualByComparingTo("133");
             assertThat(response.getToCurrency()).isEqualTo("KRW");
-            assertThat(response.getToAmount()).isEqualByComparingTo("127823");
-            assertThat(response.getTradeRate()).isEqualByComparingTo("1278.23");
+            assertThat(response.getToAmount()).isEqualByComparingTo("196104");
+            assertThat(response.getTradeRate()).isEqualByComparingTo("1474.47");
         }
 
         @Test
@@ -123,7 +122,7 @@ class OrderServiceTest {
             // Arrange: 5000 JPY, sellRate 871.57 → 5000 * 871.57 / 100 = 43578.5 → FLOOR → 43578
             givenRate(Currency.JPY, "963.31", "871.57");
             givenSavedOrder();
-            OrderRequest request = new OrderRequest(OrderType.SELL, Currency.JPY, new BigDecimal("5000"));
+            OrderRequest request = new OrderRequest(new BigDecimal("5000"), Currency.JPY, Currency.KRW);
 
             // Act
             OrderResponse response = orderService.createOrder(request);
@@ -138,13 +137,22 @@ class OrderServiceTest {
     class Validation {
 
         @Test
-        @DisplayName("KRW 통화로 주문하면 InvalidCurrencyException을 던진다")
-        void rejectsKrwOrder() {
-            OrderRequest request = new OrderRequest(OrderType.BUY, Currency.KRW, new BigDecimal("100"));
+        @DisplayName("KRW가 포함되지 않은 통화쌍은 거부한다")
+        void rejectsNonKrwPair() {
+            OrderRequest request = new OrderRequest(new BigDecimal("100"), Currency.USD, Currency.EUR);
 
             assertThatThrownBy(() -> orderService.createOrder(request))
                     .isInstanceOf(InvalidCurrencyException.class)
                     .hasMessageContaining("KRW");
+        }
+
+        @Test
+        @DisplayName("같은 통화끼리 주문하면 거부한다")
+        void rejectsSameCurrency() {
+            OrderRequest request = new OrderRequest(new BigDecimal("100"), Currency.KRW, Currency.KRW);
+
+            assertThatThrownBy(() -> orderService.createOrder(request))
+                    .isInstanceOf(InvalidCurrencyException.class);
         }
 
         @Test
@@ -153,7 +161,7 @@ class OrderServiceTest {
             given(exchangeRateService.getLatestRate(Currency.USD))
                     .willThrow(new RateNotFoundException("USD 환율 없음"));
 
-            OrderRequest request = new OrderRequest(OrderType.BUY, Currency.USD, new BigDecimal("100"));
+            OrderRequest request = new OrderRequest(new BigDecimal("100"), Currency.KRW, Currency.USD);
 
             assertThatThrownBy(() -> orderService.createOrder(request))
                     .isInstanceOf(RateNotAvailableException.class);
@@ -179,11 +187,11 @@ class OrderServiceTest {
         void returnsOrderResponses() {
             ForexOrder order = ForexOrder.builder()
                     .id(1L)
-                    .fromAmount(new BigDecimal("141278"))
+                    .fromAmount(new BigDecimal("296086"))
                     .fromCurrency(Currency.KRW)
-                    .toAmount(new BigDecimal("100"))
+                    .toAmount(new BigDecimal("200"))
                     .toCurrency(Currency.USD)
-                    .tradeRate(new BigDecimal("1412.78"))
+                    .tradeRate(new BigDecimal("1480.43"))
                     .dateTime(LocalDateTime.now())
                     .build();
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,3 +7,6 @@ koreaexim:
 
 scheduler:
   enabled: false
+
+exchange-rate:
+  random-variation: false


### PR DESCRIPTION
## Summary
과제 원문 API 명세와 불일치하는 부분을 수정합니다.

## 변경 내용

### CRITICAL 수정
1. **주문 Request**: `orderType`/`currency` → `fromCurrency`/`toCurrency`로 변경
   - 매수: `fromCurrency=KRW, toCurrency=USD` → buyRate 적용
   - 매도: `fromCurrency=USD, toCurrency=KRW` → sellRate 적용
2. **환율 조회 응답**: `returnObject`를 `{ exchangeRateList: [...] }`로 감싸기
3. **주문 목록 응답**: `returnObject`를 `{ orderList: [...] }`로 감싸기

### HIGH 수정
4. **OrderType enum 제거**: 과제 명세에 없는 필드. fromCurrency/toCurrency에서 매수/매도 자동 판단
5. **통화쌍 검증 강화**: KRW 포함 필수, 동일 통화 거부

### MEDIUM 수정
6. **스케줄러 랜덤 변동**: 환율 미변동 시 ±2% 범위 내 랜덤 적용 (`exchange-rate.random-variation` 설정으로 제어)

## 설계 결정

### fromCurrency/toCurrency 기반 매수/매도 판단
과제 명세에서 orderType 필드가 없고, `fromCurrency=KRW`면 매수, `toCurrency=KRW`면 매도로 구분합니다. 이는 REST API에서 리소스의 상태(from/to)만으로 행위(buy/sell)를 결정하는 방식으로, 클라이언트가 명시적으로 매수/매도를 지정할 필요가 없습니다.

### 랜덤 변동 설정 분리
테스트에서는 정확한 계산 검증이 필요하므로 랜덤을 비활성화해야 합니다. `exchange-rate.random-variation` 프로퍼티로 제어하여 테스트 환경과 운영 환경을 분리했습니다.

## Test Plan
- [x] 매수: KRW→USD 200, buyRate 1480.43 → KRW 296,086
- [x] 매도: USD→KRW 133, sellRate 1474.47 → KRW 196,104
- [x] KRW 미포함 통화쌍 거부 (USD→EUR)
- [x] 동일 통화 거부 (KRW→KRW)
- [x] JPY 100엔 단위 매수/매도
- [x] 환율 미존재 시 예외
- [x] 기존 환율 테스트 전체 통과

closes #10