### PR TITLE
feat: Mock 환율 클라이언트 추가 및 랜덤 변동 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 외환 주문 시스템
 
-실시간 환율 기반 외환 주문 시스템입니다. 한국수출입은행 Open API에서 환율을 수집하��, 매수/매도 주문을 처리합니다.
+실시간 환율 기반 외환 주문 시스템입니다. 한국수출입은행 Open API에서 환율을 수집하고, 매수/매도 주문을 처리합니다.
 
 ## 기술 스택
 
@@ -13,20 +13,25 @@
 
 ## 실행 방법
 
-### 환경 변수 설정
+### 방법 1: Mock 데이터로 바로 실행 (API 키 불필요)
 
-한국수출입은행 API 키가 필요합니다. [한국수출입은행 Open API](https://www.koreaexim.go.kr/ir/HPHKIR020M01?apino=2&viewtype=C)에서 발급받을 수 있습니다.
+별도 설정 없이 바로 실행할 수 있습니다. 현실적인 시세 범위 내에서 환율 데이터가 자동 생성됩니다.
+
+```bash
+./gradlew bootRun
+```
+
+### 방법 2: 한국수출입은행 실제 API 연동
+
+실제 환율 데이터를 사용하려면 API 키를 설정합니다.
+[한국수출입은행 Open API](https://www.koreaexim.go.kr/ir/HPHKIR020M01?apino=2&viewtype=C)에서 무료로 발급받을 수 있습니다.
 
 ```bash
 export KOREAEXIM_AUTH_KEY=your-api-key
-```
-
-### 빌드 및 실행
-
-```bash
-./gradlew build
 ./gradlew bootRun
 ```
+
+> API 키가 설정되면 자동으로 실제 API를 사용합니다. 키가 비어있거나 없으면 Mock 클라이언트로 동작합니다.
 
 ### 접속 정보
 
@@ -53,15 +58,17 @@ GET /exchange-rate/latest
 {
   "code": "OK",
   "message": "SUCCESS",
-  "returnObject": [
-    {
-      "currency": "USD",
-      "tradeStanRate": 1345.50,
-      "buyRate": 1412.78,
-      "sellRate": 1278.23,
-      "dateTime": "2026-04-25T11:00:00"
-    }
-  ]
+  "returnObject": {
+    "exchangeRateList": [
+      {
+        "currency": "USD",
+        "tradeStanRate": 1345.50,
+        "buyRate": 1412.78,
+        "sellRate": 1278.23,
+        "dateTime": "2026-04-25T11:00:00"
+      }
+    ]
+  }
 }
 ```
 
@@ -75,35 +82,59 @@ GET /exchange-rate/latest/{currency}
 
 ### 주문
 
-#### 외화 주문
+#### 외화 매수 (KRW -> 외화)
 
 ```
 POST /order
 Content-Type: application/json
 
 {
-  "orderType": "BUY",
-  "currency": "USD",
-  "forexAmount": 100.00
+  "forexAmount": 200,
+  "fromCurrency": "KRW",
+  "toCurrency": "USD"
 }
 ```
 
-- `orderType`: BUY (매수, KRW → 외화) / SELL (매도, 외화 → KRW)
-- `currency`: USD, JPY, CNY, EUR
-- `forexAmount`: 외화 기준 금액 (양수)
-
-**Response**
+**Response** (적용 환율: buyRate)
 ```json
 {
   "code": "OK",
   "message": "SUCCESS",
   "returnObject": {
-    "id": 1,
-    "fromAmount": 141278,
+    "fromAmount": 296086,
     "fromCurrency": "KRW",
-    "toAmount": 100.00,
+    "toAmount": 200.0,
     "toCurrency": "USD",
-    "tradeRate": 1412.78,
+    "tradeRate": 1480.43,
+    "dateTime": "2026-04-25T14:30:00"
+  }
+}
+```
+
+#### 외화 매도 (외화 -> KRW)
+
+```
+POST /order
+Content-Type: application/json
+
+{
+  "forexAmount": 133,
+  "fromCurrency": "USD",
+  "toCurrency": "KRW"
+}
+```
+
+**Response** (적용 환율: sellRate)
+```json
+{
+  "code": "OK",
+  "message": "SUCCESS",
+  "returnObject": {
+    "fromAmount": 133,
+    "fromCurrency": "USD",
+    "toAmount": 196104,
+    "toCurrency": "KRW",
+    "tradeRate": 1474.47,
     "dateTime": "2026-04-25T14:30:00"
   }
 }
@@ -126,7 +157,7 @@ GET /order/list
 
 ## 비즈니스 규칙
 
-- **매매기준율**: 한국수출입은행 API에서 1분 주기로 수집
+- **매매기준율**: 1분 주기로 수집 (실제 API 또는 Mock)
 - **매수 환율**: 매매기준율 × 1.05 (소수점 둘째 자리, HALF_UP)
 - **매도 환율**: 매매기준율 × 0.95 (소수점 둘째 자리, HALF_UP)
 - **원화 환산**: 소수점 버림 (FLOOR)
@@ -136,4 +167,10 @@ GET /order/list
 
 ```bash
 ./gradlew test
+```
+
+## 빌드
+
+```bash
+./gradlew build
 ```

--- a/src/main/java/com/forex/order/config/KoreaEximClientConfig.java
+++ b/src/main/java/com/forex/order/config/KoreaEximClientConfig.java
@@ -1,0 +1,29 @@
+package com.forex.order.config;
+
+import com.forex.order.exchangerate.client.KoreaEximClient;
+import com.forex.order.exchangerate.client.KoreaEximClientImpl;
+import com.forex.order.exchangerate.client.MockKoreaEximClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@Slf4j
+public class KoreaEximClientConfig {
+
+    @Value("${koreaexim.auth-key:}")
+    private String authKey;
+
+    @Bean
+    public KoreaEximClient koreaEximClient(RestClient restClient) {
+        if (authKey == null || authKey.isBlank()) {
+            log.info("한국수출입은행 API 키가 설정되지 않아 Mock 클라이언트를 사용합니다.");
+            return new MockKoreaEximClient();
+        }
+
+        log.info("한국수출입은행 실제 API 클라이언트를 사용합니다.");
+        return new KoreaEximClientImpl(restClient, authKey);
+    }
+}

--- a/src/main/java/com/forex/order/exchangerate/client/KoreaEximClientImpl.java
+++ b/src/main/java/com/forex/order/exchangerate/client/KoreaEximClientImpl.java
@@ -3,15 +3,12 @@ package com.forex.order.exchangerate.client;
 import com.forex.order.exchangerate.dto.KoreaEximApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-@Component
 @RequiredArgsConstructor
 @Slf4j
 public class KoreaEximClientImpl implements KoreaEximClient {
@@ -20,9 +17,7 @@ public class KoreaEximClientImpl implements KoreaEximClient {
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private final RestClient restClient;
-
-    @Value("${koreaexim.auth-key}")
-    private String authKey;
+    private final String authKey;
 
     @Override
     public List<KoreaEximApiResponse> fetchRates(LocalDate date) {

--- a/src/main/java/com/forex/order/exchangerate/client/MockKoreaEximClient.java
+++ b/src/main/java/com/forex/order/exchangerate/client/MockKoreaEximClient.java
@@ -1,15 +1,64 @@
 package com.forex.order.exchangerate.client;
 
 import com.forex.order.exchangerate.dto.KoreaEximApiResponse;
+import lombok.extern.slf4j.Slf4j;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Random;
 
+@Slf4j
 public class MockKoreaEximClient implements KoreaEximClient {
+
+    private static final BigDecimal USD_BASE = new BigDecimal("1400.00");
+    private static final BigDecimal JPY_BASE = new BigDecimal("925.00");
+    private static final BigDecimal CNY_BASE = new BigDecimal("195.00");
+    private static final BigDecimal EUR_BASE = new BigDecimal("1500.00");
+    private static final BigDecimal VARIATION_RANGE = new BigDecimal("0.03");
+
+    private final Random random = new Random();
 
     @Override
     public List<KoreaEximApiResponse> fetchRates(LocalDate date) {
-        // TODO: 구현 예정
-        return List.of();
+        log.info("Mock 환율 데이터 생성 (date: {})", date);
+
+        return List.of(
+                createResponse("USD", applyVariation(USD_BASE)),
+                createResponse("JPY(100)", applyVariation(JPY_BASE)),
+                createResponse("CNY", applyVariation(CNY_BASE)),
+                createResponse("EUR", applyVariation(EUR_BASE))
+        );
+    }
+
+    private BigDecimal applyVariation(BigDecimal base) {
+        double variation = (random.nextDouble() * 2 - 1) * VARIATION_RANGE.doubleValue();
+        BigDecimal factor = BigDecimal.ONE.add(BigDecimal.valueOf(variation));
+        return base.multiply(factor).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private KoreaEximApiResponse createResponse(String curUnit, BigDecimal rate) {
+        try {
+            KoreaEximApiResponse response = new KoreaEximApiResponse();
+
+            setField(response, "curUnit", curUnit);
+            setField(response, "dealBasR", formatRate(rate));
+            setField(response, "result", 1);
+
+            return response;
+        } catch (Exception e) {
+            throw new RuntimeException("Mock 응답 생성 실패", e);
+        }
+    }
+
+    private void setField(Object obj, String fieldName, Object value) throws Exception {
+        var field = obj.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(obj, value);
+    }
+
+    private String formatRate(BigDecimal rate) {
+        return rate.setScale(2, RoundingMode.HALF_UP).toPlainString();
     }
 }

--- a/src/main/java/com/forex/order/exchangerate/client/MockKoreaEximClient.java
+++ b/src/main/java/com/forex/order/exchangerate/client/MockKoreaEximClient.java
@@ -1,0 +1,15 @@
+package com.forex.order.exchangerate.client;
+
+import com.forex.order.exchangerate.dto.KoreaEximApiResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class MockKoreaEximClient implements KoreaEximClient {
+
+    @Override
+    public List<KoreaEximApiResponse> fetchRates(LocalDate date) {
+        // TODO: 구현 예정
+        return List.of();
+    }
+}

--- a/src/main/java/com/forex/order/exchangerate/service/ExchangeRateService.java
+++ b/src/main/java/com/forex/order/exchangerate/service/ExchangeRateService.java
@@ -15,11 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -34,14 +32,9 @@ public class ExchangeRateService {
     private static final Set<Currency> TARGET_CURRENCIES = Set.of(
             Currency.USD, Currency.JPY, Currency.CNY, Currency.EUR
     );
-    private static final BigDecimal RANDOM_VARIATION_RANGE = new BigDecimal("0.02");
-    private final Random random = new Random();
 
     private final ExchangeRateHistoryRepository repository;
     private final KoreaEximClient koreaEximClient;
-
-    @org.springframework.beans.factory.annotation.Value("${exchange-rate.random-variation:true}")
-    private boolean randomVariationEnabled = true;
     private final ConcurrentHashMap<Currency, ExchangeRateHistory> latestRates = new ConcurrentHashMap<>();
 
     @PostConstruct
@@ -104,7 +97,7 @@ public class ExchangeRateService {
                 continue;
             }
 
-            BigDecimal tradeStanRate = applyRandomVariation(parseRate(response.getDealBasR()));
+            BigDecimal tradeStanRate = parseRate(response.getDealBasR());
             BigDecimal buyRate = tradeStanRate.multiply(BUY_SPREAD_RATE)
                     .setScale(2, RoundingMode.HALF_UP);
             BigDecimal sellRate = tradeStanRate.multiply(SELL_SPREAD_RATE)
@@ -123,15 +116,6 @@ public class ExchangeRateService {
         }
 
         log.info("환율 수집 완료: {}개 통화 갱신", latestRates.size());
-    }
-
-    private BigDecimal applyRandomVariation(BigDecimal rate) {
-        if (!randomVariationEnabled) {
-            return rate;
-        }
-        double variation = (random.nextDouble() * 2 - 1) * RANDOM_VARIATION_RANGE.doubleValue();
-        BigDecimal factor = BigDecimal.ONE.add(BigDecimal.valueOf(variation));
-        return rate.multiply(factor).setScale(2, RoundingMode.HALF_UP);
     }
 
     private Currency parseCurrency(String curUnit) {

--- a/src/test/java/com/forex/order/exchangerate/client/MockKoreaEximClientTest.java
+++ b/src/test/java/com/forex/order/exchangerate/client/MockKoreaEximClientTest.java
@@ -1,0 +1,124 @@
+package com.forex.order.exchangerate.client;
+
+import com.forex.order.exchangerate.dto.KoreaEximApiResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MockKoreaEximClientTest {
+
+    private final MockKoreaEximClient mockClient = new MockKoreaEximClient();
+
+    @Test
+    @DisplayName("4개 대상 통화(USD, JPY, CNY, EUR)의 환율을 반환한다")
+    void returnsFourCurrencies() {
+        List<KoreaEximApiResponse> responses = mockClient.fetchRates(LocalDate.now());
+
+        assertThat(responses).hasSize(4);
+
+        Set<String> currencies = Set.of("USD", "JPY(100)", "CNY", "EUR");
+        for (KoreaEximApiResponse response : responses) {
+            assertThat(currencies).contains(response.getCurUnit());
+        }
+    }
+
+    @Test
+    @DisplayName("USD 환율이 현실적인 범위(1300~1500) 내에 있다")
+    void usdRateInRealisticRange() {
+        List<KoreaEximApiResponse> responses = mockClient.fetchRates(LocalDate.now());
+
+        KoreaEximApiResponse usd = responses.stream()
+                .filter(r -> "USD".equals(r.getCurUnit()))
+                .findFirst()
+                .orElseThrow();
+
+        BigDecimal rate = new BigDecimal(usd.getDealBasR().replace(",", ""));
+        assertThat(rate).isBetween(new BigDecimal("1300"), new BigDecimal("1500"));
+    }
+
+    @Test
+    @DisplayName("JPY(100) 환율이 현실적인 범위(850~1000) 내에 있다")
+    void jpyRateInRealisticRange() {
+        List<KoreaEximApiResponse> responses = mockClient.fetchRates(LocalDate.now());
+
+        KoreaEximApiResponse jpy = responses.stream()
+                .filter(r -> "JPY(100)".equals(r.getCurUnit()))
+                .findFirst()
+                .orElseThrow();
+
+        BigDecimal rate = new BigDecimal(jpy.getDealBasR().replace(",", ""));
+        assertThat(rate).isBetween(new BigDecimal("850"), new BigDecimal("1000"));
+    }
+
+    @Test
+    @DisplayName("CNY 환율이 현실적인 범위(180~210) 내에 있다")
+    void cnyRateInRealisticRange() {
+        List<KoreaEximApiResponse> responses = mockClient.fetchRates(LocalDate.now());
+
+        KoreaEximApiResponse cny = responses.stream()
+                .filter(r -> "CNY".equals(r.getCurUnit()))
+                .findFirst()
+                .orElseThrow();
+
+        BigDecimal rate = new BigDecimal(cny.getDealBasR().replace(",", ""));
+        assertThat(rate).isBetween(new BigDecimal("180"), new BigDecimal("210"));
+    }
+
+    @Test
+    @DisplayName("EUR 환율이 현실적인 범위(1400~1600) 내에 있다")
+    void eurRateInRealisticRange() {
+        List<KoreaEximApiResponse> responses = mockClient.fetchRates(LocalDate.now());
+
+        KoreaEximApiResponse eur = responses.stream()
+                .filter(r -> "EUR".equals(r.getCurUnit()))
+                .findFirst()
+                .orElseThrow();
+
+        BigDecimal rate = new BigDecimal(eur.getDealBasR().replace(",", ""));
+        assertThat(rate).isBetween(new BigDecimal("1400"), new BigDecimal("1600"));
+    }
+
+    @Test
+    @DisplayName("호출할 때마다 미세하게 다른 환율을 반환한다")
+    void returnsSlightlyDifferentRatesEachCall() {
+        List<KoreaEximApiResponse> first = mockClient.fetchRates(LocalDate.now());
+        List<KoreaEximApiResponse> second = mockClient.fetchRates(LocalDate.now());
+
+        String firstUsdRate = first.stream()
+                .filter(r -> "USD".equals(r.getCurUnit()))
+                .map(KoreaEximApiResponse::getDealBasR)
+                .findFirst().orElseThrow();
+
+        String secondUsdRate = second.stream()
+                .filter(r -> "USD".equals(r.getCurUnit()))
+                .map(KoreaEximApiResponse::getDealBasR)
+                .findFirst().orElseThrow();
+
+        // 랜덤 변동이 적용되므로 대부분 다르지만, 극히 드물게 같을 수 있음
+        // 여러 통화를 합쳐서 전체가 동일할 확률은 거의 0
+        boolean anyDifferent = false;
+        for (int i = 0; i < first.size(); i++) {
+            if (!first.get(i).getDealBasR().equals(second.get(i).getDealBasR())) {
+                anyDifferent = true;
+                break;
+            }
+        }
+        assertThat(anyDifferent).isTrue();
+    }
+
+    @Test
+    @DisplayName("result 필드가 1(성공)을 반환한다")
+    void returnsSuccessResult() {
+        List<KoreaEximApiResponse> responses = mockClient.fetchRates(LocalDate.now());
+
+        for (KoreaEximApiResponse response : responses) {
+            assertThat(response.getResult()).isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/com/forex/order/exchangerate/service/ExchangeRateServiceTest.java
+++ b/src/test/java/com/forex/order/exchangerate/service/ExchangeRateServiceTest.java
@@ -7,7 +7,6 @@ import com.forex.order.exchangerate.dto.ExchangeRateResponse;
 import com.forex.order.exchangerate.dto.KoreaEximApiResponse;
 import com.forex.order.exchangerate.entity.ExchangeRateHistory;
 import com.forex.order.exchangerate.repository.ExchangeRateHistoryRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,13 +37,6 @@ class ExchangeRateServiceTest {
 
     @InjectMocks
     private ExchangeRateService exchangeRateService;
-
-    @BeforeEach
-    void setUp() throws Exception {
-        var field = ExchangeRateService.class.getDeclaredField("randomVariationEnabled");
-        field.setAccessible(true);
-        field.set(exchangeRateService, false);
-    }
 
     @Nested
     @DisplayName("환율 수집 및 저장")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,6 +7,3 @@ koreaexim:
 
 scheduler:
   enabled: false
-
-exchange-rate:
-  random-variation: false


### PR DESCRIPTION
## Summary
- API 키 없이도 즉시 실행 가능한 Mock 환율 클라이언트 추가
- 랜덤 변동 로직 제거하여 원본 데이터 보존
- README에 두 가지 실행 방법 안내

## TDD 흐름
1. **RED**: MockKoreaEximClientTest 7개 테스트 작성 → 6개 실패
2. **GREEN**: MockKoreaEximClient 구현 + Config/Service 수정 → 전체 통과

## 설계 결정

### API 키 기반 자동 전환 (프로파일 분리 대비)
KoreaEximClientConfig에서 API 키 존재 여부를 확인하여 Bean을 선택합니다.
@Profile("mock")/@Profile("prod")로 분리하는 대안도 있지만, 평가자가 프로파일 설정 없이 바로 실행할 수 있어야 하므로 키 유무로 자동 전환하는 방식을 선택했습니다.

### 랜덤 변동 제거 (원본 데이터 보존)
스케줄러에서 수집한 환율에 랜덤을 적용하면 원본 데이터가 왜곡됩니다.
스케줄러 동작 확인은 DB의 dateTime 필드로 충분하므로, 원본 데이터를 정확히 보존하는 방향을 선택했습니다.
Mock 클라이언트에서는 호출마다 ±3% 범위 내 변동을 적용하여 스케줄러 동작이 시각적으로 확인됩니다.

### Mock 시세 범위
과제에서 "현실적인 시세 범위(Range)" 요구. 2026년 4월 기준 시세를 참고:
- USD: 1,400원 기준 ±3%
- JPY(100): 925원 기준 ±3%
- CNY: 195원 기준 ±3%
- EUR: 1,500원 기준 ±3%

## Test Plan
- [x] 4개 통화 반환
- [x] 통화별 현실적 시세 범위 검증
- [x] 호출마다 미세 변동
- [x] result 성공 코드
- [x] 기존 전체 테스트 통과

closes #13