### PR TITLE
fix: 한국수출입은행 API CNH → CNY 매핑 추가

### DIFF
--- a/src/main/java/com/forex/order/exchangerate/service/ExchangeRatePersistService.java
+++ b/src/main/java/com/forex/order/exchangerate/service/ExchangeRatePersistService.java
@@ -14,6 +14,7 @@ import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,9 @@ public class ExchangeRatePersistService {
 
     private static final BigDecimal BUY_SPREAD_RATE = new BigDecimal("1.05");
     private static final BigDecimal SELL_SPREAD_RATE = new BigDecimal("0.95");
+    private static final Map<String, String> CURRENCY_ALIAS = Map.of(
+            "CNH", "CNY"
+    );
 
     private final ExchangeRateHistoryRepository repository;
 
@@ -60,6 +64,7 @@ public class ExchangeRatePersistService {
             return null;
         }
         String code = curUnit.replaceAll("\\(.*\\)", "").trim();
+        code = CURRENCY_ALIAS.getOrDefault(code, code);
         try {
             return Currency.valueOf(code);
         } catch (IllegalArgumentException e) {

--- a/src/test/java/com/forex/order/exchangerate/service/ExchangeRatePersistServiceTest.java
+++ b/src/test/java/com/forex/order/exchangerate/service/ExchangeRatePersistServiceTest.java
@@ -88,6 +88,19 @@ class ExchangeRatePersistServiceTest {
     }
 
     @Test
+    @DisplayName("한국수출입은행 API의 CNH를 CNY로 매핑하여 저장한다")
+    void mapsCnhToCny() {
+        given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        List<ExchangeRateHistory> result = persistService.processAndSave(
+                List.of(new KoreaEximApiResponse("CNH", null, "195.50", 1)));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCurrency()).isEqualTo(Currency.CNY);
+        assertThat(result.get(0).getTradeStanRate()).isEqualByComparingTo("195.50");
+    }
+
+    @Test
     @DisplayName("대상 통화(USD, JPY, CNY, EUR)만 저장한다")
     void savesOnlyTargetCurrencies() {
         given(repository.save(any())).willAnswer(inv -> inv.getArgument(0));


### PR DESCRIPTION
## Summary
한국수출입은행 API가 중국 위안화를 CNY가 아닌 CNH(역외 위안화)로 제공하여 4개 대상 통화 중 CNY만 수집되지 않던 버그를 수정합니다.

## TDD 흐름
1. **RED**: CNH → CNY 매핑 테스트 추가 → 1개 실패
2. **GREEN**: CURRENCY_ALIAS Map으로 매핑 → 전체 통과

## 원인 분석
실제 API 키로 테스트한 결과, 한국수출입은행 API 응답에서 중국 위안화의 cur_unit이 \`CNY\`가 아닌 \`CNH\`임을 확인했습니다.

- CNY: 중국 본토 내에서 거래되는 역내 위안화 (onshore)
- CNH: 중국 본토 밖에서 거래되는 역외 위안화 (offshore)
- 한국수출입은행은 역외 시장 기준으로 제공하므로 CNH를 사용

## 해결 방법
\`CURRENCY_ALIAS\` Map을 통해 외부 API의 통화 코드 차이를 파싱 단계에서 흡수합니다.

```java
private static final Map<String, String> CURRENCY_ALIAS = Map.of("CNH", "CNY");
```

Currency enum은 과제 명세대로 \`CNY\`를 유지하여, API 응답과 내부 도메인 모델의 네이밍 차이를 한 곳에서 관리합니다. 향후 다른 API의 통화 코드 차이가 발생해도 이 Map에 추가하면 됩니다.

## Test Plan
- [x] CNH 입력 → CNY로 저장 확인
- [x] 기존 전체 테스트 통과

closes #23